### PR TITLE
feat: add provider-registry contract and unit test mocks

### DIFF
--- a/dmnm/contracts/provider-registry.clar
+++ b/dmnm/contracts/provider-registry.clar
@@ -1,0 +1,65 @@
+;; provider-registry.clar
+
+;; Decentralized Mobile Network Marketplace - Provider Registry Contract
+
+;; -------------------------
+;; ADMINISTRATIVE STRUCTURE
+;; -------------------------
+(define-data-var admin principal tx-sender)
+
+;; -------------------------
+;; ERROR CONSTANTS
+;; -------------------------
+(define-constant ERR-NOT-AUTHORIZED u100)
+(define-constant ERR-ALREADY-VERIFIED u101)
+(define-constant ERR-NOT-FOUND u102)
+
+;; -------------------------
+;; DATA MAPS
+;; -------------------------
+(define-map verified-providers principal bool)
+
+;; -------------------------
+;; PRIVATE FUNCTIONS
+;; -------------------------
+(define-private (is-admin)
+  (is-eq tx-sender (var-get admin))
+)
+
+;; -------------------------
+;; PUBLIC FUNCTIONS
+;; -------------------------
+
+;; Add a verified provider (only admin)
+(define-public (add-provider (provider principal))
+  (begin
+    (asserts! (is-admin) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-none (map-get? verified-providers provider)) (err ERR-ALREADY-VERIFIED))
+    (map-set verified-providers provider true)
+    (ok true)
+  )
+)
+
+;; Remove a verified provider (only admin)
+(define-public (remove-provider (provider principal))
+  (begin
+    (asserts! (is-admin) (err ERR-NOT-AUTHORIZED))
+    (asserts! (is-some (map-get? verified-providers provider)) (err ERR-NOT-FOUND))
+    (map-delete verified-providers provider)
+    (ok true)
+  )
+)
+
+;; Transfer admin rights
+(define-public (transfer-admin (new-admin principal))
+  (begin
+    (asserts! (is-admin) (err ERR-NOT-AUTHORIZED))
+    (var-set admin new-admin)
+    (ok true)
+  )
+)
+
+;; Check if provider is verified
+(define-read-only (is-verified-provider (provider principal))
+  (default-to false (map-get? verified-providers provider))
+)

--- a/dmnm/deployments/default.simnet-plan.yaml
+++ b/dmnm/deployments/default.simnet-plan.yaml
@@ -1,0 +1,59 @@
+---
+id: 0
+name: "Simulated deployment, used as a default for `clarinet console`, `clarinet test` and `clarinet check`"
+network: simnet
+genesis:
+  wallets:
+    - name: deployer
+      address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: faucet
+      address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_1
+      address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_2
+      address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_3
+      address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_4
+      address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_5
+      address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_6
+      address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_7
+      address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_8
+      address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+  contracts:
+    - costs
+    - pox
+    - pox-2
+    - pox-3
+    - pox-4
+    - lockup
+    - costs-2
+    - costs-3
+    - cost-voting
+    - bns
+plan:
+  batches: []

--- a/dmnm/tests/provider-registry.test.ts
+++ b/dmnm/tests/provider-registry.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from "vitest"
+
+// Mock Clarity contract behavior
+const mockContract = {
+  admin: "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+  verifiedProviders: new Map<string, boolean>(),
+
+  isAdmin(caller: string) {
+    return caller === this.admin
+  },
+
+  addProvider(caller: string, provider: string) {
+    if (!this.isAdmin(caller)) {
+      return { error: 100 } // ERR-NOT-AUTHORIZED
+    }
+
+    if (this.verifiedProviders.has(provider)) {
+      return { error: 101 } // ERR-ALREADY-VERIFIED
+    }
+
+    this.verifiedProviders.set(provider, true)
+    return { value: true }
+  },
+
+  removeProvider(caller: string, provider: string) {
+    if (!this.isAdmin(caller)) {
+      return { error: 100 } // ERR-NOT-AUTHORIZED
+    }
+
+    if (!this.verifiedProviders.has(provider)) {
+      return { error: 102 } // ERR-NOT-FOUND
+    }
+
+    this.verifiedProviders.delete(provider)
+    return { value: true }
+  },
+
+  isVerifiedProvider(provider: string) {
+    return this.verifiedProviders.has(provider)
+  },
+
+  transferAdmin(caller: string, newAdmin: string) {
+    if (!this.isAdmin(caller)) {
+      return { error: 100 } // ERR-NOT-AUTHORIZED
+    }
+
+    this.admin = newAdmin
+    return { value: true }
+  },
+}
+
+describe("Provider Registry Contract", () => {
+  beforeEach(() => {
+    mockContract.admin = "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM"
+    mockContract.verifiedProviders = new Map()
+  })
+
+  it("should add a new provider when called by admin", () => {
+    const result = mockContract.addProvider(
+      "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+      "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG"
+    )
+    expect(result).toEqual({ value: true })
+    expect(mockContract.isVerifiedProvider("ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG")).toBe(true)
+  })
+
+  it("should fail to add provider when called by non-admin", () => {
+    const result = mockContract.addProvider(
+      "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG",
+      "ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP"
+    )
+    expect(result).toEqual({ error: 100 }) // ERR-NOT-AUTHORIZED
+    expect(mockContract.isVerifiedProvider("ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP")).toBe(false)
+  })
+
+  it("should fail to add an already verified provider", () => {
+    mockContract.addProvider(
+      "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+      "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG"
+    )
+
+    const result = mockContract.addProvider(
+      "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+      "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG"
+    )
+
+    expect(result).toEqual({ error: 101 }) // ERR-ALREADY-VERIFIED
+  })
+
+  it("should remove a provider when called by admin", () => {
+    mockContract.addProvider(
+      "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+      "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG"
+    )
+
+    const result = mockContract.removeProvider(
+      "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+      "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG"
+    )
+
+    expect(result).toEqual({ value: true })
+    expect(mockContract.isVerifiedProvider("ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG")).toBe(false)
+  })
+
+  it("should transfer admin rights", () => {
+    const result = mockContract.transferAdmin(
+      "ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM",
+      "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG"
+    )
+
+    expect(result).toEqual({ value: true })
+    expect(mockContract.admin).toBe("ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG")
+
+    const addResult = mockContract.addProvider(
+      "ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG",
+      "ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP"
+    )
+    expect(addResult).toEqual({ value: true })
+  })
+})


### PR DESCRIPTION
This PR introduces the `provider-registry.clar` contract and corresponding TypeScript mock tests for the Decentralized Mobile Network Marketplace (DMNM) project.

### Changes

- ✅ Clarity contract for managing verified telecom providers
- 🔐 Admin-only access control
- 📦 Functions for adding, removing, and verifying providers
- 🔄 Transfer of admin rights
- 🧪 Mock unit tests in TypeScript using Vitest

### Notes

- Aligned with Clarity v1 syntax and best practices
- Designed for modular integration into the full smart contract suite
